### PR TITLE
Corrected link to original dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Also , Existing Datasets are being listed here!
 
 
 ### BANGLA FAKE NEWS DETECTION
-* [50k BANGLA fake news dataset](https://github.com/Rowan1697/FakeNews)
+* [50k BANGLA fake news dataset](https://www.kaggle.com/cryptexcode/banfakenews)
 * 
 
 ### MISC


### PR DESCRIPTION
Corrected the Bangla fake news dataset link. The full dataset is hosted on Kaggle.